### PR TITLE
[FLINK-30964][build] Fetch all release branches under correct local repo path

### DIFF
--- a/sync_repo.sh
+++ b/sync_repo.sh
@@ -14,12 +14,12 @@ date > .last-sync
 if [ ! -d ".repo" ]; then
 	echo "SOURCE_REPO ($SOURCE_REPO) does not exist. Cloning ..."
 	git clone --mirror $SOURCE_REPO .repo
+        cd .repo
 else
 	# update list of current branches
+        cd .repo
 	git fetch origin 'refs/heads/release-*:refs/release-*'
 fi
-
-cd .repo
 
 # echo "Fetching from SOURCE_REPO ($SOURCE_REPO)"
 # git fetch origin master


### PR DESCRIPTION
The PR aims to fix the flink-mirror sync failure due to the scripts fetch release branches under an incorrect local path