### PR TITLE
[FLINK-30965][ci] Adds more complex CI sync branch selection

### DIFF
--- a/sync_repo.sh
+++ b/sync_repo.sh
@@ -24,7 +24,8 @@ fi
 # echo "Fetching from SOURCE_REPO ($SOURCE_REPO)"
 # git fetch origin master
 
-for RELEASE_BRANCH in `git branch -a | grep "release-" | grep -v "rc" | sort -V -r | head -n 2` ; do
+# the 3 most-recent release branches need to be covered when a new release branch is cut but the release is not finalized, yet
+for RELEASE_BRANCH in `git branch -a | grep "release-" | grep -v "rc" | sort -V -r | head -n 3` ; do
 	TARGET_BRANCHES+=" $RELEASE_BRANCH"
 done
 


### PR DESCRIPTION
The new selection method only starts to ignore the soon-to-be-deprecated release branch `release-X.{Y-2}` if the new minor release is finalized by creating the
corresponding `release-X.Y.0` release tag. Previously, the soon-to-be-deprecated release branch would be
ignored as soon as the newest release branch `release-X.Y` is cut.